### PR TITLE
fix club creation

### DIFF
--- a/jira_;)/bugs.txt
+++ b/jira_;)/bugs.txt
@@ -3,4 +3,4 @@ UI
 - no way to navigate off player info page back to the player list
 
 CORE
-- cannot add new clubs to the game
+- delete club does not work

--- a/jira_;)/tasks.txt
+++ b/jira_;)/tasks.txt
@@ -17,6 +17,7 @@ UI
 - value of ObjectListWidget?
 - fix add venue wizard
 - fix add match report wizard
+- club creation has no titles to explain what you are setting
 
 
 MATCHES

--- a/src/application.py
+++ b/src/application.py
@@ -47,11 +47,9 @@ class Application:
 
     def add_club(self, club_data: ClubCreationData) -> None:
         """Function to add a new club object. Should probably be in the database layer."""
-        print("ADD CLUB")
-        print(club_data)
         os.mkdir(self._get_data_folder() + club_data.name)
-        self.clubs.append(club_data.name)
-        # self.clubs.sort()
+        self.clubs.append(club_data)
+        self.clubs.sort()
 
     def clear_local_data(self):
         """Deletes all local data"""

--- a/ui/pages/club_selector.py
+++ b/ui/pages/club_selector.py
@@ -9,7 +9,6 @@ class ClubSelector(PageBase):
         super().__init__(manager, root)
 
     def setup_content(self):
-        print("ClubSelector: setup content")
         for club in self.page_manager.app.clubs:
             Button(self, text=club.name,
                    command=lambda c=club: self.select_club(c)).pack()
@@ -17,7 +16,6 @@ class ClubSelector(PageBase):
         Button(self, text="Add", command=self.handle_add_club).pack(side=BOTTOM)
 
     def handle_add_club(self):
-        print("add club")
         self.page_manager.open_subpage(AddClubWizard)
 
     def select_club(self, club):


### PR DESCRIPTION
Whenever we introduced ClubCreationData we didn't correctly adjust add creation to use that instead of accessing the string